### PR TITLE
Fix for Integration Test Failure

### DIFF
--- a/modules/integration/tests-integration/src/test/java/org/wso2/iot/integration/mobileDevice/MobileDeviceManagementWithNoDevices.java
+++ b/modules/integration/tests-integration/src/test/java/org/wso2/iot/integration/mobileDevice/MobileDeviceManagementWithNoDevices.java
@@ -58,7 +58,7 @@ public class MobileDeviceManagementWithNoDevices extends TestBase {
 
         while (!checkScopes(Constants.APIApplicationRegistration.PERMISSION_LIST)) {
             TimeUnit.SECONDS.sleep(5);
-            long WAIT_TIME = 30000;
+            long WAIT_TIME = 60000;
             if (System.currentTimeMillis() - startTime > WAIT_TIME) {
                 Assert.fail("Required APIs are not deployed after waiting for " + WAIT_TIME + " time-out has happened");
             }


### PR DESCRIPTION
Increasing wait time for test to ensure all relevant APIs have been deployed.