### PR TITLE
Fixes for [EMM-1816] By default https://localhost:9443/ redirect to carbon console - redirect to /emm instead

### DIFF
--- a/modules/components/org.wso2.iot.core.admin.styles/src/main/resources/META-INF/component.xml
+++ b/modules/components/org.wso2.iot.core.admin.styles/src/main/resources/META-INF/component.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<component xmlns="http://products.wso2.org/carbon">
+
+    <contexts>
+        <context>
+            <context-id>default-context</context-id>
+            <context-name>devicemgt</context-name>
+            <protocol>https</protocol>
+            <description>IoT Server Default Context</description>
+        </context>
+    </contexts>
+</component>


### PR DESCRIPTION
fixed https://github.com/wso2/product-iots/issues/555