### PR TITLE
Inherit maven assembly plugin from carbon-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1761,10 +1761,6 @@
                     </executions>
                 </plugin>
                 <plugin>
-                    <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.0.0</version>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
                     <version>2.4</version>


### PR DESCRIPTION
Products shouldn't re-define or override what is available in carbon-parent without a proper reason.
This has done in compliance with recent build efficiency effort.
Please check if you have used this assembly plugin version for specific reason.
If not you can inherit from the carbon-parent.