### PR TITLE
Adding additional wait for exe file creation

### DIFF
--- a/modules/integration/tests-common/integration-common/src/main/java/org/wso2/iot/integration/common/extensions/CarbonServerManagerExtension.java
+++ b/modules/integration/tests-common/integration-common/src/main/java/org/wso2/iot/integration/common/extensions/CarbonServerManagerExtension.java
@@ -414,14 +414,12 @@ public class CarbonServerManagerExtension {
                 log.info("Execution data file non empty file size in KB : " + file.length() / 1024);
                 break;
             } else {
-
                 try {
                     log.warn("Execution data file is empty file size in KB : " + file.length() / 1024);
                     Thread.sleep(500);
                 } catch (InterruptedException ignored) {
                     log.warn("Sleep interrupted ", ignored);
                 }
-
             }
         }
     }

--- a/modules/integration/tests-common/integration-common/src/main/java/org/wso2/iot/integration/common/extensions/CarbonServerManagerExtension.java
+++ b/modules/integration/tests-common/integration-common/src/main/java/org/wso2/iot/integration/common/extensions/CarbonServerManagerExtension.java
@@ -18,6 +18,9 @@
 
 package org.wso2.iot.integration.common.extensions;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.DirectoryFileFilter;
+import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -36,6 +39,7 @@ import org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader;
 import javax.xml.xpath.XPathExpressionException;
 import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -57,6 +61,7 @@ public class CarbonServerManagerExtension {
     private static final String CMD_ARG = "cmdArg";
     private static int defaultHttpPort = Integer.parseInt("9763");
     private static int defaultHttpsPort = Integer.parseInt("9443");
+    private static final long COVERAGE_DUMP_WAIT_TIME = 30000;
 
     public CarbonServerManagerExtension(AutomationContext context) {
         this.automationContext = context;
@@ -246,6 +251,7 @@ public class CarbonServerManagerExtension {
     }
 
     private void generateCoverageReport(File classesDir) throws IOException, AutomationFrameworkException {
+        checkJacocoDataFileSizes(FrameworkPathUtil.getJacocoCoverageHome());
         CodeCoverageUtils.executeMerge(FrameworkPathUtil.getJacocoCoverageHome(), FrameworkPathUtil.getCoverageMergeFilePath());
         ReportGenerator reportGenerator = new ReportGenerator(new File(FrameworkPathUtil.getCoverageMergeFilePath()), classesDir, new File(CodeCoverageUtils.getJacocoReportDirectory()), (File)null);
         reportGenerator.create();
@@ -374,4 +380,50 @@ public class CarbonServerManagerExtension {
         }
 
     }
+
+    /**
+     * To check jacoco file sizes and wait for them to get created..
+     *
+     * @param filePath File Path of the jacoco data files.
+     */
+    private void checkJacocoDataFileSizes(String filePath) {
+        Collection<File> fileSetsCollection = FileUtils
+                .listFiles(new File(filePath), new RegexFileFilter("[^s]+(." + "(?i)(exec))$"),
+                        DirectoryFileFilter.DIRECTORY);
+
+        for (File inputFile : fileSetsCollection) {
+            if (inputFile.isDirectory()) {
+                continue;
+            }
+            //retry to check whether exec data file is non empty.
+            waitForCoverageDumpFileCreation(inputFile);
+        }
+    }
+
+    /**
+     * This is to wait for jacoco exe file creation.
+     *
+     * @param file File that need to be created.
+     */
+    private void waitForCoverageDumpFileCreation(File file) {
+        long currentTime = System.currentTimeMillis();
+        long waitTime = currentTime + COVERAGE_DUMP_WAIT_TIME;
+
+        while (waitTime > System.currentTimeMillis()) {
+            if (file.length() > 0) {
+                log.info("Execution data file non empty file size in KB : " + file.length() / 1024);
+                break;
+            } else {
+
+                try {
+                    log.warn("Execution data file is empty file size in KB : " + file.length() / 1024);
+                    Thread.sleep(500);
+                } catch (InterruptedException ignored) {
+                    log.warn("Sleep interrupted ", ignored);
+                }
+
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
## Purpose
> Jacoco file exe file creation takes more than 10 secs, it in-turn leads to build failure.

## Goals
> This PR adds an extra wait time for jacoco file creation. While waiting it will also check whether file is created successfully. If it is created, it will not wait after that.

## Approach
> This is a fix for the build failure.

## User stories
> N/A

## Release note
> This is a fix for build failure. Not a bug fix or feature

## Documentation
> N/A. This is not a bug fix or feature.

## Training
> N/A

## Certification
> N/A. This is not a product specific fix

## Marketing
> N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Oracle JDK 1.8, Ubuntu 16.04
 
## Learning
> N/A