### PR TITLE
Separating core device management logic from the api layer.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
     </dependencyManagement>
 
     <properties>
-        <carbon.devicemgt.version>4.0.4</carbon.devicemgt.version>
+        <carbon.devicemgt.version>4.0.5</carbon.devicemgt.version>
 
         <carbon.kernel.version>5.2.0</carbon.kernel.version>
         <carbon.kernel.product.version>5.2.0</carbon.kernel.product.version>

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -168,6 +168,12 @@
             <version>${carbon.devicemgt.version}</version>
             <type>zip</type>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.devicemgt</groupId>
+            <artifactId>org.wso2.carbon.device.mgt.core.feature</artifactId>
+            <version>${carbon.devicemgt.version}</version>
+            <type>zip</type>
+        </dependency>
     </dependencies>
 
     <build>
@@ -314,6 +320,10 @@
                                     <id>org.wso2.carbon.device.mgt.api.feature</id>
                                     <version>${carbon.devicemgt.version}</version>
                                 </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.device.mgt.core.feature</id>
+                                    <version>${carbon.devicemgt.version}</version>
+                                </feature>
                             </features>
                         </configuration>
                     </execution>
@@ -434,6 +444,10 @@
                                 <!--Device Management Dependencies-->
                                 <feature>
                                     <id>org.wso2.carbon.device.mgt.api.feature</id>
+                                    <version>${carbon.devicemgt.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.device.mgt.core.feature</id>
                                     <version>${carbon.devicemgt.version}</version>
                                 </feature>
                             </features>


### PR DESCRIPTION
## Purpose
> Device management core should be available as a separate feature.

## Goals
> Separating core device management logic from the api layer.

## Approach
> Moved core device management logics into the "org.wso2.carbon.device.mgt.core" feature. Moreover; "org.wso2.carbon.device.mgt.api" has a feature dependency for the above feature.

## Related PRs
> https://github.com/wso2/carbon-device-mgt/pull/1115