### PR TITLE
Adding notification for the user on a Websocket handshake failure

### DIFF
--- a/modules/distribution/src/core/samples/connectedcup/component/ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.connectedcup.realtime.analytics-view/analytics-view.hbs
+++ b/modules/distribution/src/core/samples/connectedcup/component/ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.connectedcup.realtime.analytics-view/analytics-view.hbs
@@ -52,6 +52,10 @@
         </span>
     </span> View Device Analytics
 </a>
+
+<div class="hide" id="websocker-onerror">
+    Realtime Analytics for $sensorType not available. Failed to connect to the websocket. Please make sure; '<a style="color: white" href="$webSocketURL">$webSocketURL</a>' is available and re-try again.
+</div>
 <!-- /statistics -->
 {{#zone "bottomJs"}}
     {{js "js/moment.min.js"}}

--- a/modules/distribution/src/core/samples/connectedcup/component/ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.connectedcup.realtime.analytics-view/public/js/device-stats.js
+++ b/modules/distribution/src/core/samples/connectedcup/component/ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.connectedcup.realtime.analytics-view/public/js/device-stats.js
@@ -114,6 +114,17 @@ function connect(wsConnection, target, chartData, graph, sensorType) {
             chartData.shift();
             graph.update();
         };
+        wsConnection.onerror = function (event) {
+            var websocketURL = event.currentTarget.url;
+            websocketURL = websocketURL.replace("wss://","https://");
+            var uriParts = websocketURL.split("/");
+            websocketURL = uriParts[0] + "//" + uriParts[2];
+            var errorMsg = $("#websocker-onerror").html();
+            errorMsg = errorMsg.replace(new RegExp('\\$sensorType', 'g'), sensorType);
+            errorMsg = errorMsg.replace(new RegExp('\\$webSocketURL', 'g'), websocketURL);
+            $(graph.element).parent().html("<div class='alert alert-danger'>" + errorMsg + "</div>");
+            $(graph.element).hide();
+        };
     }
     if (sensorType == "temperature") {
         wsConnectionTemperature = wsConnection;

--- a/modules/distribution/src/core/samples/sampledevice/component/ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.sampledevice.realtime.analytics-view/analytics-view.hbs
+++ b/modules/distribution/src/core/samples/sampledevice/component/ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.sampledevice.realtime.analytics-view/analytics-view.hbs
@@ -37,6 +37,9 @@
         <i class="fw fw-statistics fw-stack-1x"></i>
     </span> View Device Analytics
 </a>
+<div class="hide" id="websocker-onerror">
+    Realtime Analytics is not available. Failed to connect to the websocket. Please make sure; '<a style="color: white" href="$webSocketURL">$webSocketURL</a>' is available and re-try again.
+</div>
 <!-- /statistics -->
 {{#zone "bottomJs"}}
     {{js "js/moment.min.js"}}

--- a/modules/distribution/src/core/samples/sampledevice/component/ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.sampledevice.realtime.analytics-view/public/js/device-stats.js
+++ b/modules/distribution/src/core/samples/sampledevice/component/ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.device.type.sampledevice.realtime.analytics-view/public/js/device-stats.js
@@ -104,6 +104,16 @@ function connect(wsConnection, target, chartData, graph) {
             chartData.shift();
             graph.update();
         };
+        wsConnection.onerror = function (event) {
+            var websocketURL = event.currentTarget.url;
+            websocketURL = websocketURL.replace("wss://","https://");
+            var uriParts = websocketURL.split("/");
+            websocketURL = uriParts[0] + "//" + uriParts[2];
+            var errorMsg = $("#websocker-onerror").html();
+            errorMsg = errorMsg.replace(new RegExp('\\$webSocketURL', 'g'), websocketURL);
+            $(graph.element).parent().html("<div class='alert alert-danger'>" + errorMsg + "</div>");
+            $(graph.element).hide();
+        };
     }
 }
 


### PR DESCRIPTION
## Purpose
> On the device's realtime analytics page; unless specified and exempted websocket URL endpoint for the IoT Analytics Server will be failed without notifying the user. This PR resolves https://github.com/wso2/product-iots/issues/1659.

## Goals
> Adding notification for the user on a Websocket handshake failure

## Approach
> N/A

## User stories
> N/A

## Release note
> Adding notification for the user on a Websocket handshake failure

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> https://github.com/wso2/carbon-device-mgt/pull/1177, https://github.com/wso2/carbon-device-mgt-plugins/pull/884

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A