### PR TITLE
Update documentation anchor links

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ http://docs.wso2.com/iot-server.
 * Support for SCEP protocol (encryption and authenticity)
 
 ### How to Run
-* Extract the downloaded wso2iot-3.1.0.zip file; this will create a folder named ‘wso2iot-3.1.0’.
+* Extract the downloaded wso2iot-3.2.0.zip file; this will create a folder named ‘wso2iot-3.2.0’.
 * IoT Server comes with three runnable components namely broker, core, and analytics. Start these components in following order by executing the following scripts:
-    * wso2iot-3.1.0//bin/broker.sh [.bat]
-    * wso2iot-3.1.0/bin/iot-server.sh [.bat]
-    * wso2iot-3.1.0/bin/analytics.sh [.bat]
+    * wso2iot-3.2.0//bin/broker.sh [.bat]
+    * wso2iot-3.2.0/bin/iot-server.sh [.bat]
+    * wso2iot-3.2.0/bin/analytics.sh [.bat]
 
 ### How to Contribute
 

--- a/modules/distribution/src/analytics/samples/device-plugins/pom.xml
+++ b/modules/distribution/src/analytics/samples/device-plugins/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.iot.analytics.devicemgt-plugins</groupId>
     <artifactId>analytics-devicetype-feature-installation</artifactId>
-    <version>3.1.0-update10-SNAPSHOT</version>
+    <version>3.2.0</version>
     <packaging>pom</packaging>
     <name>Install Virtual Fire Alarm, Raspberry Pi, Arduino Device Types - Analytics</name>
     <url>http://wso2.org</url>

--- a/modules/distribution/src/assembly/filter.properties
+++ b/modules/distribution/src/assembly/filter.properties
@@ -18,7 +18,7 @@
 
 product.name=WSO2 IoT Server
 product.key=IoT
-product.version=3.1.0
+product.version=3.2.0
 product.doc.version=310
 
 carbon.version=4.4.16

--- a/modules/distribution/src/core/release-notes.html
+++ b/modules/distribution/src/core/release-notes.html
@@ -35,7 +35,7 @@
 
 <h4>Documentation</h4>
 
-Documentations: <a href='https://docs.wso2.com/display/IoTS310/WSO2+IoT+Server+Documentation'> WSO2 IoT Server Documentation</a> 
+Documentations: <a href='https://docs.wso2.com/display/IoTS320/WSO2+IoT+Server+Documentation'> WSO2 IoT Server Documentation</a>
 
 <h4>Known Issues</h4>
 

--- a/modules/distribution/src/core/samples/device-plugins-deployer.xml
+++ b/modules/distribution/src/core/samples/device-plugins-deployer.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.iot.devicemgt-plugins</groupId>
     <artifactId>iot-devicetype-feature-installation</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Install Virtual Fire Alarm, Raspberry Pi, Arduino Device Types - IoT Core</name>
     <url>http://wso2.org</url>

--- a/modules/scripts/mobile-qsg/resources/Readme.txt
+++ b/modules/scripts/mobile-qsg/resources/Readme.txt
@@ -1,5 +1,5 @@
 
-WSO2 IoTs 3.1.0 QSG Setup Guide
+WSO2 IoTs 3.2.0 QSG Setup Guide
 ---------------------------------
 
 1. Start the WSO2 IoTS server


### PR DESCRIPTION
## Purpose
> Updating documentation anchor links in UIs. Resolves https://github.com/wso2/product-iots/issues/1694

## Goals
> Updating documentation anchor links in UIs. 

## Approach
> Updating documentation anchor links in UIs. 

## User stories
> N/A

## Release note
> Updating documentation anchor links in UIs. 

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> https://github.com/wso2/carbon-device-mgt/pull/1201
https://github.com/wso2/carbon-device-mgt-plugins/pull/892

## Migrations (if applicable)
> N/A

## Test environment
> Apache Maven 3.5.2
Maven home: /usr/local/Cellar/maven/3.5.2/libexec
Java version: 1.8.0_152, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0_152.jdk/Contents/Home/jre
Default locale: en_LK, platform encoding: UTF-8
OS name: "mac os x", version: "10.13.3", arch: "x86_64", family: "mac"
 
## Learning
> N/A