### PR TITLE
Correcting issues with creating a docker image

### DIFF
--- a/product/docker/Dockerfile
+++ b/product/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8u111-jdk
-COPY /maven/wso2iot.zip .
+COPY wso2iot-4.0.0-SNAPSHOT.zip .
 RUN apt-get update && apt-get install unzip
-RUN unzip wso2iot.zip -d wso2am
+RUN unzip wso2iot-4.0.0-SNAPSHOT.zip -d wso2iot
 EXPOSE 9090
-ENTRYPOINT ["wso2iot/WSO2IoT-4.0.0-SNAPSHOT/bin/carbon.sh"]
+ENTRYPOINT ["wso2iot/wso2iot-4.0.0-SNAPSHOT/bin/iotserver.sh"]


### PR DESCRIPTION
## Purpose
> Creating docker image with IoT Serer C5 Distro

## Goals
> Current docker container creation script is wrong. This PR seeks to correct it.

## Approach
> Corrected paths associated with Docker Image creation
- to create docker image run the command : docker build --tag "docker-wso2iot:c5" .
- can run the image after with docker run, and the iot server will get started up

## User stories
> N/A

## Release note
> Correcting issues with creating a docker image with IoT Server c5 distro

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A