### PR TITLE
Add iot.http.port to iot-server.sh

### DIFF
--- a/modules/distribution/src/core/bin/iot-server.sh
+++ b/modules/distribution/src/core/bin/iot-server.sh
@@ -323,6 +323,7 @@ do
     -Dmqtt.broker.port="1886" \
     -Diot.core.host="localhost" \
     -Diot.core.https.port="9443" \
+    -Diot.core.http.port="9763" \
     -Diot.keymanager.host="localhost" \
     -Diot.keymanager.https.port="9443" \
     -Diot.gateway.host="localhost" \


### PR DESCRIPTION
## Purpose
> Added iot.http.port to iot-server.sh. This is introduced as a fix for wso2/product-iots#1869